### PR TITLE
Fix brew apps not showing in launchpad

### DIFF
--- a/brew-launchpad-function.sh
+++ b/brew-launchpad-function.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Функция для установки приложений через Homebrew с автоматическим добавлением в Launchpad
+# Добавьте эту функцию в ваш .zshrc или .bash_profile
+
+function brew_install_launchpad() {
+    local app_name="$1"
+    
+    if [ -z "$app_name" ]; then
+        echo "Использование: brew_install_launchpad название_приложения"
+        return 1
+    fi
+    
+    echo "🚀 Устанавливаю $app_name через Homebrew Cask..."
+    
+    # Устанавливаем приложение
+    brew install --cask "$app_name"
+    
+    if [ $? -eq 0 ]; then
+        echo "✅ Установка завершена"
+        
+        # Проверяем, где установилось приложение
+        local home_apps="$HOME/Applications/$app_name.app"
+        local system_apps="/Applications/$app_name.app"
+        
+        if [ -d "$home_apps" ]; then
+            echo "📁 Приложение найдено в ~/Applications, перемещаю в /Applications..."
+            sudo mv "$home_apps" "/Applications/"
+            
+            if [ $? -eq 0 ]; then
+                echo "✅ $app_name успешно перемещен в /Applications"
+                # Обновляем Dock для отображения в Launchpad
+                killall Dock 2>/dev/null
+                echo "🎉 $app_name теперь доступен в Launchpad!"
+            else
+                echo "❌ Ошибка при перемещении $app_name"
+            fi
+            
+        elif [ -d "$system_apps" ]; then
+            echo "✅ $app_name уже находится в /Applications и доступен в Launchpad"
+            
+        else
+            echo "⚠️  Приложение $app_name не найдено в стандартных папках"
+            echo "Проверьте установку командой: brew list --cask | grep $app_name"
+        fi
+        
+    else
+        echo "❌ Ошибка при установке $app_name"
+        return 1
+    fi
+}
+
+# Алиас для удобства
+alias binstall='brew_install_launchpad'
+
+echo "Функция brew_install_launchpad готова к использованию!"
+echo "Использование: brew_install_launchpad название_приложения"
+echo "Или: binstall название_приложения"

--- a/brew-launchpad.sh
+++ b/brew-launchpad.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Скрипт для установки приложений через Homebrew с автоматическим добавлением в Launchpad
+# Использование: ./brew-launchpad.sh install --cask название_приложения
+
+# Функция для перемещения приложения в /Applications
+move_to_applications() {
+    local app_name="$1"
+    local home_apps="$HOME/Applications/$app_name.app"
+    local system_apps="/Applications/$app_name.app"
+    
+    if [ -d "$home_apps" ]; then
+        echo "Перемещаю $app_name из ~/Applications в /Applications..."
+        sudo mv "$home_apps" "/Applications/"
+        if [ $? -eq 0 ]; then
+            echo "✅ $app_name успешно перемещен в /Applications"
+            # Обновляем Dock для отображения в Launchpad
+            killall Dock 2>/dev/null
+        else
+            echo "❌ Ошибка при перемещении $app_name"
+        fi
+    elif [ -d "$system_apps" ]; then
+        echo "✅ $app_name уже находится в /Applications"
+    else
+        echo "⚠️  Приложение $app_name не найдено в ~/Applications или /Applications"
+    fi
+}
+
+# Функция для установки через brew
+brew_install() {
+    echo "Устанавливаю приложение через Homebrew..."
+    brew "$@"
+    
+    if [ $? -eq 0 ] && [[ "$*" == *"--cask"* ]]; then
+        # Извлекаем название приложения из аргументов
+        local app_name=""
+        for arg in "$@"; do
+            if [[ "$arg" != "--cask" && "$arg" != "install" ]]; then
+                app_name="$arg"
+                break
+            fi
+        done
+        
+        if [ -n "$app_name" ]; then
+            echo "Проверяю расположение приложения $app_name..."
+            move_to_applications "$app_name"
+        fi
+    fi
+}
+
+# Основная логика
+if [ "$1" = "install" ] && [[ "$*" == *"--cask"* ]]; then
+    brew_install "$@"
+else
+    # Если это не установка cask, просто передаем команду в brew
+    brew "$@"
+fi

--- a/brew-setup.sh
+++ b/brew-setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Скрипт для настройки удобных алиасов для Homebrew
+
+echo "Настраиваю алиасы для Homebrew..."
+
+# Добавляем алиасы в .zshrc (для zsh) или .bash_profile (для bash)
+SHELL_CONFIG=""
+
+if [ -f "$HOME/.zshrc" ]; then
+    SHELL_CONFIG="$HOME/.zshrc"
+elif [ -f "$HOME/.bash_profile" ]; then
+    SHELL_CONFIG="$HOME/.bash_profile"
+elif [ -f "$HOME/.bashrc" ]; then
+    SHELL_CONFIG="$HOME/.bashrc"
+fi
+
+if [ -n "$SHELL_CONFIG" ]; then
+    # Проверяем, не добавлены ли уже алиасы
+    if ! grep -q "alias binstall" "$SHELL_CONFIG"; then
+        echo "" >> "$SHELL_CONFIG"
+        echo "# Homebrew aliases for Launchpad integration" >> "$SHELL_CONFIG"
+        echo "alias binstall='brew install --cask'" >> "$SHELL_CONFIG"
+        echo "alias bupdate='brew update && brew upgrade'" >> "$SHELL_CONFIG"
+        echo "alias bclean='brew cleanup'" >> "$SHELL_CONFIG"
+        echo "alias bsearch='brew search'" >> "$SHELL_CONFIG"
+        echo "" >> "$SHELL_CONFIG"
+        echo "# Функция для автоматического перемещения приложений в Launchpad" >> "$SHELL_CONFIG"
+        echo "function move_to_launchpad() {" >> "$SHELL_CONFIG"
+        echo "    local app_name=\"\$1\"" >> "$SHELL_CONFIG"
+        echo "    if [ -d \"\$HOME/Applications/\$app_name.app\" ]; then" >> "$SHELL_CONFIG"
+        echo "        echo \"Перемещаю \$app_name в /Applications...\"" >> "$SHELL_CONFIG"
+        echo "        sudo mv \"\$HOME/Applications/\$app_name.app\" \"/Applications/\"" >> "$SHELL_CONFIG"
+        echo "        killall Dock 2>/dev/null" >> "$SHELL_CONFIG"
+        echo "        echo \"✅ \$app_name добавлен в Launchpad\"" >> "$SHELL_CONFIG"
+        echo "    else" >> "$SHELL_CONFIG"
+        echo "        echo \"⚠️  Приложение \$app_name не найдено в ~/Applications\"" >> "$SHELL_CONFIG"
+        echo "    fi" >> "$SHELL_CONFIG"
+        echo "}" >> "$SHELL_CONFIG"
+        echo "" >> "$SHELL_CONFIG"
+        echo "✅ Алиасы добавлены в $SHELL_CONFIG"
+        echo "Перезапустите терминал или выполните: source $SHELL_CONFIG"
+    else
+        echo "✅ Алиасы уже настроены в $SHELL_CONFIG"
+    fi
+else
+    echo "❌ Не найден файл конфигурации shell (.zshrc, .bash_profile или .bashrc)"
+fi
+
+echo ""
+echo "Теперь вы можете использовать:"
+echo "  binstall название_приложения  - для установки с автоматическим добавлением в Launchpad"
+echo "  move_to_launchpad название_приложения  - для ручного перемещения в Launchpad"


### PR DESCRIPTION
Add scripts and shell functions to automate Homebrew Cask application installation into Launchpad.

This change provides several methods (wrapper script, aliases, shell function) to ensure applications installed via `brew install --cask` automatically appear in macOS Launchpad by moving them to `/Applications` if needed and refreshing the Dock.

---
<a href="https://cursor.com/background-agent?bcId=bc-34961ac9-acf9-41e6-825c-6bc8059b674f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34961ac9-acf9-41e6-825c-6bc8059b674f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

